### PR TITLE
Encode content & reverse posts in RSS

### DIFF
--- a/src/rss.njk
+++ b/src/rss.njk
@@ -26,7 +26,7 @@
     <name>{{ metadata.author.name }}</name>
     <email>{{ metadata.author.email }}</email>
   </author>
-  {% for post in collections.post %}
+  {% for post in collections.post | reverse %}
   {% if not post.externalLink %}
 
     {% set absolutePostUrl %}{{ post.url | url | absoluteUrl(metadata.url) }}{% endset %}
@@ -35,7 +35,9 @@
       <link href="{{ absolutePostUrl }}"/>
       <updated>{{ post.date | rssDate }}</updated>
       <id>{{ absolutePostUrl }}</id>
-      <content type="html">{{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }}</content>
+      <content type="html">
+        <![CDATA[ {{ post.templateContent | htmlToAbsoluteUrls(absolutePostUrl) }} ]]>
+      </content>
     </entry>
     {% endif %}
   {% endfor %}


### PR DESCRIPTION
Hi,

I hope i'm not overstepping the mark - if I am, feel free to close this PR (and sorry!)

I am currently developing an RSS reader of sorts as a side project, and your feed is an excellent resource (and one I definitely want to include), however it seems the feed is broken 😔.

This commit encodes the content, which enables HTML to appear in the RSS content. It also reverses the post order, as some RSS readers go from the top of the file and if the ID exists already then they exit.

The feed is still not valid after this fix, however, due to the pesky apostrophe in [this post](https://github.com/mbarker84/css-irl-eleventy/blob/master/src/posts/goodbye-2020.md) (you can see Github is having trouble encoding it).

I started writing a find/replace - but realised this requires several changes to your codebase that I don't feel comfortable doing without your say-so! Would recommend changing the apostrophe to a boring one (sorry).

Thanks again for the great content & happy new year! 🎉